### PR TITLE
feat: add componentId parameter for duplicate component id

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -49,7 +49,7 @@ const rpc = createRPCClient(
         filter: '',
       })
       const flattenedChildren = flattenChildren(inspectorTree[0])
-      const targetNode = flattenedChildren.find(child => child.name === query.componentName)
+      const targetNode = flattenedChildren.find(child => child.id === query.componentId)
       const inspectorState = await devtools.api.getInspectorState({
         inspectorId: COMPONENTS_INSPECTOR_ID,
         nodeId: targetNode.id,
@@ -64,7 +64,7 @@ const rpc = createRPCClient(
         filter: '',
       })
       const flattenedChildren = flattenChildren(inspectorTree[0])
-      const targetNode = flattenedChildren.find(child => child.name === query.componentName)
+      const targetNode = flattenedChildren.find(child => child.id === query.componentId)
       const payload = {
         inspectorId: COMPONENTS_INSPECTOR_ID,
         nodeId: targetNode.id,
@@ -88,7 +88,7 @@ const rpc = createRPCClient(
         filter: '',
       })
       const flattenedChildren = flattenChildren(inspectorTree[0])
-      const targetNode = flattenedChildren.find(child => child.name === query.componentName)
+      const targetNode = flattenedChildren.find(child => child.id === query.componentId)
       devtools.ctx.hooks.callHook('componentHighlight', { uid: targetNode.id })
       highlightComponentTimeout = setTimeout(() => {
         devtools.ctx.hooks.callHook('componentUnhighlight')

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,9 +43,10 @@ export function createMcpServerDefault(
     'get-component-state',
     'Get the Vue component state in JSON structure format.',
     {
+      componentId: z.string(),
       componentName: z.string(),
     },
-    async ({ componentName }) => {
+    async ({ componentId, componentName }) => {
       return new Promise((resolve) => {
         const eventName = nanoid()
         ctx.hooks.hookOnce(eventName, (res) => {
@@ -56,7 +57,7 @@ export function createMcpServerDefault(
             }],
           })
         })
-        ctx.rpcServer.getInspectorState({ event: eventName, componentName })
+        ctx.rpcServer.getInspectorState({ event: eventName, componentId, componentName })
       })
     },
   )
@@ -65,14 +66,15 @@ export function createMcpServerDefault(
     'edit-component-state',
     'Edit the Vue component state.',
     {
+      componentId: z.string(),
       componentName: z.string(),
       path: z.array(z.string()),
       value: z.string(),
       valueType: z.enum(['string', 'number', 'boolean', 'object', 'array']),
     },
-    async ({ componentName, path, value, valueType }) => {
+    async ({ componentId, componentName, path, value, valueType }) => {
       return new Promise((resolve) => {
-        ctx.rpcServer.editComponentState({ componentName, path, value, valueType })
+        ctx.rpcServer.editComponentState({ componentId, componentName, path, value, valueType })
         resolve({
           content: [{
             type: 'text',
@@ -87,11 +89,12 @@ export function createMcpServerDefault(
     'highlight-component',
     'Highlight the Vue component.',
     {
+      componentId: z.string(),
       componentName: z.string(),
     },
-    async ({ componentName }) => {
+    async ({ componentId, componentName }) => {
       return new Promise((resolve) => {
-        ctx.rpcServer.highlightComponent({ componentName })
+        ctx.rpcServer.highlightComponent({ componentId, componentName })
         resolve({
           content: [{
             type: 'text',

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,10 +9,10 @@ export interface RpcFunctions {
   // components
   getInspectorTree: (options: { event: string, componentName?: string }) => void
   onInspectorTreeUpdated: (event: string, data: string) => void
-  getInspectorState: (options: { event: string, componentName: string }) => void
+  getInspectorState: (options: { event: string, componentId: string, componentName: string }) => void
   onInspectorStateUpdated: (event: string, data: string) => void
-  editComponentState: (options: { componentName: string, path: string[], value: string, valueType: string }) => void
-  highlightComponent: (options: { componentName: string }) => void
+  editComponentState: (options: { componentName: string, componentId: string, path: string[], value: string, valueType: string }) => void
+  highlightComponent: (options: { componentName: string, componentId: string }) => void
   // router
   getRouterInfo: (options: { event: string }) => void
   onRouterInfoUpdated: (event: string, data: string) => void


### PR DESCRIPTION
## Component State Management for v-for Components

close #16

### Issue Description
When using v-for to render multiple instances of the same component, the componentName alone is insufficient to uniquely identify each component instance. This causes issues when trying to manage state for specific component instances in a v-for loop.

### Current Behavior
- Components rendered with v-for share the same componentName
- Unable to target specific component instances using componentName alone
- State modifications may affect wrong component instances

### Expected Behavior
- Each component instance in v-for should be uniquely identifiable
- Ability to modify state for specific component instances
- Clear distinction between components with the same name

### Solution Implemented
Added componentId parameter to component state management functions:
- Updated getInspectorState to accept componentId
- Modified editComponentState to use componentId for targeting specific instances
- Enhanced component identification in the devtools

### Example
```vue
<template>
  <div v-for="(item, index) in items" :key="index">
    <Count /> <!-- Multiple Count components with same name but different IDs -->
  </div>
</template>
```