### PR TITLE
fix: prevent MCP tool hangs and unhandled promise crashes

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -1,21 +1,31 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ViteDevServer } from 'vite'
 import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
-import DEBUG from 'debug'
 
-const debug = DEBUG('vite:mcp:server')
+// eslint-disable-next-line no-console
+const log = (...args: any[]): void => console.log(...args)
 
 export async function setupRoutes(base: string, server: McpServer, vite: ViteDevServer): Promise<void> {
   const transports = new Map<string, SSEServerTransport>()
 
   vite.middlewares.use(`${base}/sse`, async (req, res) => {
-    const transport = new SSEServerTransport(`${base}/messages`, res)
-    transports.set(transport.sessionId, transport)
-    debug('SSE Connected %s', transport.sessionId)
-    res.on('close', () => {
-      transports.delete(transport.sessionId)
-    })
-    await server.connect(transport)
+    try {
+      const transport = new SSEServerTransport(`${base}/messages`, res)
+      transports.set(transport.sessionId, transport)
+      log(`[vue-mcp] SSE client connected: ${transport.sessionId}`)
+      res.on('close', () => {
+        log(`[vue-mcp] SSE client disconnected: ${transport.sessionId}`)
+        transports.delete(transport.sessionId)
+      })
+      await server.connect(transport)
+    }
+    catch (e) {
+      console.error('[vue-mcp] SSE connection error:', e)
+      if (!res.headersSent) {
+        res.statusCode = 500
+        res.end('Internal Server Error')
+      }
+    }
   })
 
   vite.middlewares.use(`${base}/messages`, async (req, res) => {
@@ -36,12 +46,22 @@ export async function setupRoutes(base: string, server: McpServer, vite: ViteDev
 
     const transport = transports.get(clientId)
     if (!transport) {
+      console.warn(`[vue-mcp] Message for unknown session: ${clientId}`)
       res.statusCode = 404
       res.end('Not Found')
       return
     }
 
-    debug('Message from %s', clientId)
-    await transport.handlePostMessage(req, res)
+    try {
+      log(`[vue-mcp] Message received from session: ${clientId}`)
+      await transport.handlePostMessage(req, res)
+    }
+    catch (e) {
+      console.error(`[vue-mcp] Message handling error for session ${clientId}:`, e)
+      if (!res.headersSent) {
+        res.statusCode = 500
+        res.end('Internal Server Error')
+      }
+    }
   })
 }

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -5,17 +5,25 @@ import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
 // eslint-disable-next-line no-console
 const log = (...args: any[]): void => console.log(...args)
 
-export async function setupRoutes(base: string, server: McpServer, vite: ViteDevServer): Promise<void> {
+export async function setupRoutes(
+  base: string,
+  createServer: () => Promise<McpServer>,
+  vite: ViteDevServer,
+): Promise<void> {
   const transports = new Map<string, SSEServerTransport>()
 
   vite.middlewares.use(`${base}/sse`, async (req, res) => {
     try {
       const transport = new SSEServerTransport(`${base}/messages`, res)
+      const server = await createServer()
       transports.set(transport.sessionId, transport)
       log(`[vue-mcp] SSE client connected: ${transport.sessionId}`)
       res.on('close', () => {
         log(`[vue-mcp] SSE client disconnected: ${transport.sessionId}`)
         transports.delete(transport.sessionId)
+        server.close().catch((e: unknown) => {
+          console.error('[vue-mcp] Error closing MCP server:', e)
+        })
       })
       await server.connect(transport)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
 import type { RpcFunctions, VueMcpContext, VueMcpOptions } from './types'
 import { existsSync } from 'node:fs'
@@ -55,9 +56,12 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
       ctx.rpcServer = rpcServer
       ctx.rpc = rpc
 
-      let mcp = await mcpServer(vite, ctx)
-      mcp = await options.mcpServerSetup?.(mcp, vite) || mcp
-      await setupRoutes(mcpPath, mcp, vite)
+      const createMcpServer = async (): Promise<McpServer> => {
+        let mcp = await mcpServer(vite, ctx)
+        mcp = await options.mcpServerSetup?.(mcp, vite) || mcp
+        return mcp
+      }
+      await setupRoutes(mcpPath, createMcpServer, vite)
 
       const port = vite.config.server.port || 5173
       const root = searchForWorkspaceRoot(vite.config.root)

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,13 +65,25 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
       const sseUrl = `http://${options.host || 'localhost'}:${port}${mcpPath}/sse`
 
       if (cursorMcpOptions.enabled) {
-        if (existsSync(join(root, '.cursor'))) {
-          const mcp = existsSync(join(root, '.cursor/mcp.json'))
-            ? JSON.parse(await fs.readFile(join(root, '.cursor/mcp.json'), 'utf-8') || '{}')
-            : {}
-          mcp.mcpServers ||= {}
-          mcp.mcpServers[cursorMcpOptions.serverName || 'vue-mcp'] = { url: sseUrl }
-          await fs.writeFile(join(root, '.cursor/mcp.json'), `${JSON.stringify(mcp, null, 2)}\n`)
+        try {
+          if (existsSync(join(root, '.cursor'))) {
+            const mcpConfigPath = join(root, '.cursor/mcp.json')
+            let mcp = {}
+            if (existsSync(mcpConfigPath)) {
+              const raw = await fs.readFile(mcpConfigPath, 'utf-8')
+              mcp = JSON.parse(raw || '{}')
+            }
+            // @ts-expect-error dynamic
+            mcp.mcpServers ||= {}
+            // @ts-expect-error dynamic
+            mcp.mcpServers[cursorMcpOptions.serverName || 'vue-mcp'] = { url: sseUrl }
+            await fs.writeFile(mcpConfigPath, `${JSON.stringify(mcp, null, 2)}\n`)
+            // eslint-disable-next-line no-console
+            console.log(`[vue-mcp] Updated ${mcpConfigPath}`)
+          }
+        }
+        catch (e) {
+          console.error('[vue-mcp] Failed to update .cursor/mcp.json:', e)
         }
       }
 

--- a/src/overlay.js
+++ b/src/overlay.js
@@ -3,9 +3,11 @@ import { devtools, devtoolsRouterInfo, devtoolsState, getInspector, stringify, t
 import { createRPCClient } from 'vite-dev-rpc'
 import { createHotContext } from 'vite-hot-client'
 
+// eslint-disable-next-line no-console
+const log = (...args) => console.log(...args)
 
 const base = import.meta.env.BASE_URL || '/'
-const hot = createHotContext('',base)
+const hot = createHotContext('', base)
 const PINIA_INSPECTOR_ID = 'pinia'
 const COMPONENTS_INSPECTOR_ID = 'components'
 
@@ -30,109 +32,190 @@ function flattenChildren(node) {
   return result
 }
 
+function findComponent(flattenedChildren, componentName, toolName) {
+  const targetNode = flattenedChildren.find(child => child.name === componentName)
+  if (!targetNode) {
+    console.warn(`[vue-mcp:browser] ${toolName}: component "${componentName}" not found in tree`)
+    return null
+  }
+  return targetNode
+}
+
+function restoreHighPerfMode(wasEnabled) {
+  if (wasEnabled) {
+    try {
+      toggleHighPerfMode(true)
+    }
+    catch (e) {
+      console.error('[vue-mcp:browser] Failed to restore high perf mode:', e)
+    }
+  }
+}
+
 const rpc = createRPCClient(
   'vite-plugin-vue-mcp',
   hot,
   {
     // get component tree
     async getInspectorTree(query) {
-      const inspectorTree = await devtools.api.getInspectorTree({
-        inspectorId: COMPONENTS_INSPECTOR_ID,
-        filter: '',
-      })
-      rpc.onInspectorTreeUpdated(query.event, inspectorTree[0])
+      log('[vue-mcp:browser] getInspectorTree called')
+      try {
+        const inspectorTree = await devtools.api.getInspectorTree({
+          inspectorId: COMPONENTS_INSPECTOR_ID,
+          filter: '',
+        })
+        log('[vue-mcp:browser] getInspectorTree resolved')
+        rpc.onInspectorTreeUpdated(query.event, inspectorTree[0])
+      }
+      catch (e) {
+        console.error('[vue-mcp:browser] getInspectorTree failed:', e)
+        rpc.onInspectorTreeUpdated(query.event, null)
+      }
     },
     // get component state
     async getInspectorState(query) {
-      const inspectorTree = await devtools.api.getInspectorTree({
-        inspectorId: COMPONENTS_INSPECTOR_ID,
-        filter: '',
-      })
-      const flattenedChildren = flattenChildren(inspectorTree[0])
-      const targetNode = flattenedChildren.find(child => child.name === query.componentName)
-      const inspectorState = await devtools.api.getInspectorState({
-        inspectorId: COMPONENTS_INSPECTOR_ID,
-        nodeId: targetNode.id,
-      })
-      rpc.onInspectorStateUpdated(query.event, stringify(inspectorState))
+      log(`[vue-mcp:browser] getInspectorState called for "${query.componentName}"`)
+      try {
+        const inspectorTree = await devtools.api.getInspectorTree({
+          inspectorId: COMPONENTS_INSPECTOR_ID,
+          filter: '',
+        })
+        const flattenedChildren = flattenChildren(inspectorTree[0])
+        const targetNode = findComponent(flattenedChildren, query.componentName, 'getInspectorState')
+        if (!targetNode) {
+          rpc.onInspectorStateUpdated(query.event, stringify({ error: `Component "${query.componentName}" not found` }))
+          return
+        }
+        const inspectorState = await devtools.api.getInspectorState({
+          inspectorId: COMPONENTS_INSPECTOR_ID,
+          nodeId: targetNode.id,
+        })
+        log('[vue-mcp:browser] getInspectorState resolved')
+        rpc.onInspectorStateUpdated(query.event, stringify(inspectorState))
+      }
+      catch (e) {
+        console.error('[vue-mcp:browser] getInspectorState failed:', e)
+        rpc.onInspectorStateUpdated(query.event, stringify({ error: String(e) }))
+      }
     },
 
     // edit component state
     async editComponentState(query) {
-      const inspectorTree = await devtools.api.getInspectorTree({
-        inspectorId: COMPONENTS_INSPECTOR_ID,
-        filter: '',
-      })
-      const flattenedChildren = flattenChildren(inspectorTree[0])
-      const targetNode = flattenedChildren.find(child => child.name === query.componentName)
-      const payload = {
-        inspectorId: COMPONENTS_INSPECTOR_ID,
-        nodeId: targetNode.id,
-        path: query.path,
-        state: {
-          new: null,
-          remove: false,
-          type: query.valueType,
-          value: query.value,
-        },
-        type: undefined,
+      log(`[vue-mcp:browser] editComponentState called for "${query.componentName}"`)
+      try {
+        const inspectorTree = await devtools.api.getInspectorTree({
+          inspectorId: COMPONENTS_INSPECTOR_ID,
+          filter: '',
+        })
+        const flattenedChildren = flattenChildren(inspectorTree[0])
+        const targetNode = findComponent(flattenedChildren, query.componentName, 'editComponentState')
+        if (!targetNode) {
+          return
+        }
+        const payload = {
+          inspectorId: COMPONENTS_INSPECTOR_ID,
+          nodeId: targetNode.id,
+          path: query.path,
+          state: {
+            new: null,
+            remove: false,
+            type: query.valueType,
+            value: query.value,
+          },
+          type: undefined,
+        }
+        await devtools.ctx.api.editInspectorState(payload)
+        log('[vue-mcp:browser] editComponentState completed')
       }
-      await devtools.ctx.api.editInspectorState(payload)
+      catch (e) {
+        console.error('[vue-mcp:browser] editComponentState failed:', e)
+      }
     },
 
     // highlight component
     async highlightComponent(query) {
-      clearTimeout(highlightComponentTimeout)
-      const inspectorTree = await devtools.api.getInspectorTree({
-        inspectorId: COMPONENTS_INSPECTOR_ID,
-        filter: '',
-      })
-      const flattenedChildren = flattenChildren(inspectorTree[0])
-      const targetNode = flattenedChildren.find(child => child.name === query.componentName)
-      devtools.ctx.hooks.callHook('componentHighlight', { uid: targetNode.id })
-      highlightComponentTimeout = setTimeout(() => {
-        devtools.ctx.hooks.callHook('componentUnhighlight')
-      }, 5000)
+      log(`[vue-mcp:browser] highlightComponent called for "${query.componentName}"`)
+      try {
+        clearTimeout(highlightComponentTimeout)
+        const inspectorTree = await devtools.api.getInspectorTree({
+          inspectorId: COMPONENTS_INSPECTOR_ID,
+          filter: '',
+        })
+        const flattenedChildren = flattenChildren(inspectorTree[0])
+        const targetNode = findComponent(flattenedChildren, query.componentName, 'highlightComponent')
+        if (!targetNode) {
+          return
+        }
+        devtools.ctx.hooks.callHook('componentHighlight', { uid: targetNode.id })
+        highlightComponentTimeout = setTimeout(() => {
+          devtools.ctx.hooks.callHook('componentUnhighlight')
+        }, 5000)
+        log('[vue-mcp:browser] highlightComponent completed')
+      }
+      catch (e) {
+        console.error('[vue-mcp:browser] highlightComponent failed:', e)
+      }
     },
     // get router info
     async getRouterInfo(query) {
-      rpc.onRouterInfoUpdated(query.event, JSON.stringify(devtoolsRouterInfo, null, 2))
+      log('[vue-mcp:browser] getRouterInfo called')
+      try {
+        rpc.onRouterInfoUpdated(query.event, JSON.stringify(devtoolsRouterInfo, null, 2))
+      }
+      catch (e) {
+        console.error('[vue-mcp:browser] getRouterInfo failed:', e)
+        rpc.onRouterInfoUpdated(query.event, JSON.stringify({ error: String(e) }))
+      }
     },
     // get pinia tree
     async getPiniaTree(query) {
+      log('[vue-mcp:browser] getPiniaTree called')
       const highPerfModeEnabled = devtoolsState.highPerfModeEnabled
-      if (highPerfModeEnabled) {
-        toggleHighPerfMode(false)
+      try {
+        if (highPerfModeEnabled) {
+          toggleHighPerfMode(false)
+        }
+        const inspectorTree = await devtools.api.getInspectorTree({
+          inspectorId: PINIA_INSPECTOR_ID,
+          filter: '',
+        })
+        restoreHighPerfMode(highPerfModeEnabled)
+        log('[vue-mcp:browser] getPiniaTree resolved')
+        rpc.onPiniaTreeUpdated(query.event, inspectorTree)
       }
-      const inspectorTree = await devtools.api.getInspectorTree({
-        inspectorId: PINIA_INSPECTOR_ID,
-        filter: '',
-      })
-      if (highPerfModeEnabled) {
-        toggleHighPerfMode(true)
+      catch (e) {
+        restoreHighPerfMode(highPerfModeEnabled)
+        console.error('[vue-mcp:browser] getPiniaTree failed:', e)
+        rpc.onPiniaTreeUpdated(query.event, null)
       }
-      rpc.onPiniaTreeUpdated(query.event, inspectorTree)
     },
     // get pinia state
     async getPiniaState(query) {
+      log(`[vue-mcp:browser] getPiniaState called for store "${query.storeName}"`)
       const highPerfModeEnabled = devtoolsState.highPerfModeEnabled
-      if (highPerfModeEnabled) {
-        toggleHighPerfMode(false)
-      }
-      const payload = {
-        inspectorId: PINIA_INSPECTOR_ID,
-        nodeId: query.storeName,
-      }
-      const inspector = getInspector(payload.inspectorId)
+      try {
+        if (highPerfModeEnabled) {
+          toggleHighPerfMode(false)
+        }
+        const payload = {
+          inspectorId: PINIA_INSPECTOR_ID,
+          nodeId: query.storeName,
+        }
+        const inspector = getInspector(payload.inspectorId)
 
-      if (inspector)
-        inspector.selectedNodeId = payload.nodeId
+        if (inspector)
+          inspector.selectedNodeId = payload.nodeId
 
-      const res = await devtools.ctx.api.getInspectorState(payload)
-      if (highPerfModeEnabled) {
-        toggleHighPerfMode(true)
+        const res = await devtools.ctx.api.getInspectorState(payload)
+        restoreHighPerfMode(highPerfModeEnabled)
+        log('[vue-mcp:browser] getPiniaState resolved')
+        rpc.onPiniaInfoUpdated(query.event, stringify(res))
       }
-      rpc.onPiniaInfoUpdated(query.event, stringify(res))
+      catch (e) {
+        restoreHighPerfMode(highPerfModeEnabled)
+        console.error('[vue-mcp:browser] getPiniaState failed:', e)
+        rpc.onPiniaInfoUpdated(query.event, stringify({ error: String(e) }))
+      }
     },
   },
   {

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,9 +5,49 @@ import { nanoid } from 'nanoid'
 import { z } from 'zod'
 import { version } from '../package.json'
 
+const TOOL_TIMEOUT = 10_000
+
+// eslint-disable-next-line no-console
+const log = (...args: any[]): void => console.log(...args)
+
+function createToolHandler(
+  ctx: VueMcpContext,
+  toolName: string,
+  rpcCall: (eventName: string) => void,
+) {
+  return () => {
+    log(`[vue-mcp] tool:${toolName} called`)
+    return new Promise<{ content: { type: 'text', text: string }[] }>((resolve, reject) => {
+      const eventName = nanoid()
+
+      const timeout = setTimeout(() => {
+        console.error(`[vue-mcp] tool:${toolName} timed out after ${TOOL_TIMEOUT}ms — is a browser tab open?`)
+        reject(new Error(`[vue-mcp] tool:${toolName} timed out — no response from browser client`))
+      }, TOOL_TIMEOUT)
+
+      ctx.hooks.hookOnce(eventName, (res) => {
+        clearTimeout(timeout)
+        log(`[vue-mcp] tool:${toolName} received response`)
+        resolve({
+          content: [{ type: 'text', text: JSON.stringify(res) }],
+        })
+      })
+
+      try {
+        rpcCall(eventName)
+      }
+      catch (e) {
+        clearTimeout(timeout)
+        console.error(`[vue-mcp] tool:${toolName} RPC call failed:`, e)
+        reject(e)
+      }
+    })
+  }
+}
+
 export function createMcpServerDefault(
   options: VueMcpOptions,
-  vite: ViteDevServer,
+  _vite: ViteDevServer,
   ctx: VueMcpContext,
 ): McpServer {
   const server = new McpServer(
@@ -21,22 +61,10 @@ export function createMcpServerDefault(
   server.tool(
     'get-component-tree',
     'Get the Vue component tree in markdown tree syntax format.',
-    {
-    },
-    async () => {
-      return new Promise((resolve) => {
-        const eventName = nanoid()
-        ctx.hooks.hookOnce(eventName, (res) => {
-          resolve({
-            content: [{
-              type: 'text',
-              text: JSON.stringify(res),
-            }],
-          })
-        })
-        ctx.rpcServer.getInspectorTree({ event: eventName })
-      })
-    },
+    {},
+    createToolHandler(ctx, 'get-component-tree', (event) => {
+      ctx.rpcServer.getInspectorTree({ event })
+    }),
   )
 
   server.tool(
@@ -46,17 +74,31 @@ export function createMcpServerDefault(
       componentName: z.string(),
     },
     async ({ componentName }) => {
-      return new Promise((resolve) => {
+      log(`[vue-mcp] tool:get-component-state called for "${componentName}"`)
+      return new Promise((resolve, reject) => {
         const eventName = nanoid()
+
+        const timeout = setTimeout(() => {
+          console.error(`[vue-mcp] tool:get-component-state timed out after ${TOOL_TIMEOUT}ms`)
+          reject(new Error(`[vue-mcp] tool:get-component-state timed out — no response from browser client`))
+        }, TOOL_TIMEOUT)
+
         ctx.hooks.hookOnce(eventName, (res) => {
+          clearTimeout(timeout)
+          log(`[vue-mcp] tool:get-component-state received response`)
           resolve({
-            content: [{
-              type: 'text',
-              text: JSON.stringify(res),
-            }],
+            content: [{ type: 'text', text: JSON.stringify(res) }],
           })
         })
-        ctx.rpcServer.getInspectorState({ event: eventName, componentName })
+
+        try {
+          ctx.rpcServer.getInspectorState({ event: eventName, componentName })
+        }
+        catch (e) {
+          clearTimeout(timeout)
+          console.error(`[vue-mcp] tool:get-component-state RPC call failed:`, e)
+          reject(e)
+        }
       })
     },
   )
@@ -71,15 +113,18 @@ export function createMcpServerDefault(
       valueType: z.enum(['string', 'number', 'boolean', 'object', 'array']),
     },
     async ({ componentName, path, value, valueType }) => {
-      return new Promise((resolve) => {
+      log(`[vue-mcp] tool:edit-component-state called for "${componentName}" path=${path.join('.')}`)
+      try {
         ctx.rpcServer.editComponentState({ componentName, path, value, valueType })
-        resolve({
-          content: [{
-            type: 'text',
-            text: 'ok',
-          }],
-        })
-      })
+        log(`[vue-mcp] tool:edit-component-state completed`)
+        return {
+          content: [{ type: 'text', text: 'ok' }],
+        }
+      }
+      catch (e) {
+        console.error(`[vue-mcp] tool:edit-component-state failed:`, e)
+        throw e
+      }
     },
   )
 
@@ -90,37 +135,28 @@ export function createMcpServerDefault(
       componentName: z.string(),
     },
     async ({ componentName }) => {
-      return new Promise((resolve) => {
+      log(`[vue-mcp] tool:highlight-component called for "${componentName}"`)
+      try {
         ctx.rpcServer.highlightComponent({ componentName })
-        resolve({
-          content: [{
-            type: 'text',
-            text: 'ok',
-          }],
-        })
-      })
+        log(`[vue-mcp] tool:highlight-component completed`)
+        return {
+          content: [{ type: 'text', text: 'ok' }],
+        }
+      }
+      catch (e) {
+        console.error(`[vue-mcp] tool:highlight-component failed:`, e)
+        throw e
+      }
     },
   )
 
   server.tool(
     'get-router-info',
     'Get the Vue router info in JSON structure format.',
-    {
-    },
-    async () => {
-      return new Promise((resolve) => {
-        const eventName = nanoid()
-        ctx.hooks.hookOnce(eventName, (res) => {
-          resolve({
-            content: [{
-              type: 'text',
-              text: JSON.stringify(res),
-            }],
-          })
-        })
-        ctx.rpcServer.getRouterInfo({ event: eventName })
-      })
-    },
+    {},
+    createToolHandler(ctx, 'get-router-info', (event) => {
+      ctx.rpcServer.getRouterInfo({ event })
+    }),
   )
 
   server.tool(
@@ -130,17 +166,31 @@ export function createMcpServerDefault(
       storeName: z.string(),
     },
     async ({ storeName }) => {
-      return new Promise((resolve) => {
+      log(`[vue-mcp] tool:get-pinia-state called for store "${storeName}"`)
+      return new Promise((resolve, reject) => {
         const eventName = nanoid()
+
+        const timeout = setTimeout(() => {
+          console.error(`[vue-mcp] tool:get-pinia-state timed out after ${TOOL_TIMEOUT}ms`)
+          reject(new Error(`[vue-mcp] tool:get-pinia-state timed out — no response from browser client`))
+        }, TOOL_TIMEOUT)
+
         ctx.hooks.hookOnce(eventName, (res) => {
+          clearTimeout(timeout)
+          log(`[vue-mcp] tool:get-pinia-state received response`)
           resolve({
-            content: [{
-              type: 'text',
-              text: JSON.stringify(res),
-            }],
+            content: [{ type: 'text', text: JSON.stringify(res) }],
           })
         })
-        ctx.rpcServer.getPiniaState({ event: eventName, storeName })
+
+        try {
+          ctx.rpcServer.getPiniaState({ event: eventName, storeName })
+        }
+        catch (e) {
+          clearTimeout(timeout)
+          console.error(`[vue-mcp] tool:get-pinia-state RPC call failed:`, e)
+          reject(e)
+        }
       })
     },
   )
@@ -148,22 +198,10 @@ export function createMcpServerDefault(
   server.tool(
     'get-pinia-tree',
     'Get the Pinia tree in JSON structure format.',
-    {
-    },
-    async () => {
-      return new Promise((resolve) => {
-        const eventName = nanoid()
-        ctx.hooks.hookOnce(eventName, (res) => {
-          resolve({
-            content: [{
-              type: 'text',
-              text: JSON.stringify(res),
-            }],
-          })
-        })
-        ctx.rpcServer.getPiniaTree({ event: eventName })
-      })
-    },
+    {},
+    createToolHandler(ctx, 'get-pinia-tree', (event) => {
+      ctx.rpcServer.getPiniaTree({ event })
+    }),
   )
 
   return server


### PR DESCRIPTION
## Summary

This PR fixes a number of fragility issues - outright crashes and subsequent silent hangs.  It fixes the issues I've been experiencing.

- **Fix silent tool response loss**: The MCP SDK's `Server` class stores a single `this._transport` reference. Each `server.connect(transport)` call replaces it, and when any old transport closes, `_onclose()` sets it to `undefined` — silently swallowing all subsequent tool responses via `this._transport?.send(...)`. Fixed by creating a **new McpServer per SSE connection** instead of sharing one across all connections.
- **Fix unhandled promise rejections crashing the server**: All tool handlers in `server.ts` used `new Promise((resolve) => { ... })` with no `reject`, no `try/catch`, and no timeout. If the browser client was disconnected or an RPC call failed, birpc rejected with a plain object (`#<Object>`), crashing the Node process. Fixed by adding `reject`, `try/catch`, and a 10s timeout to all tool handlers.
- **Fix null dereference in browser overlay**: `overlay.js` called `targetNode.id` without checking if `findComponent()` returned `undefined`. This crashed the browser when a component name didn't exist in the tree, propagating back as the `#<Object>` unhandled rejection on the server.
- **Add error handling to SSE/messages middleware**: Both `connect.ts` middleware handlers were async with no `try/catch`, making any SDK error an unhandled rejection.
- **Add error handling to `.cursor/mcp.json` I/O**: Invalid JSON in the config file crashed Vite startup.
- **Add console logging to all tool calls and connection lifecycle events**

Addresses #32 