### PR TITLE
fix: SSE reconnection crash + Nuxt overlay injection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,13 @@
-# vite-plugin-vue-mcp
+# @nonfx/vite-plugin-vue-mcp
+
+> **This is a patched fork of [vite-plugin-vue-mcp](https://github.com/webfansplz/vite-plugin-vue-mcp) by [@webfansplz](https://github.com/webfansplz).**
+>
+> It includes two bug fixes that are [pending upstream (PR #36)](https://github.com/webfansplz/vite-plugin-vue-mcp/pull/36):
+>
+> 1. **SSE reconnection crash** — when an MCP client disconnects and reconnects, the server threw `"Already connected to a transport"` and stopped working until the dev server was restarted.
+> 2. **Nuxt support** — `transformIndexHtml` is not called in Nuxt, so the client overlay script was never injected and all MCP tool calls hung indefinitely. This fork auto-detects Nuxt and injects via the `transform` hook instead.
+>
+> Once these fixes land in the upstream package, prefer using `vite-plugin-vue-mcp` directly.
 
 [![npm version][npm-version-src]][npm-version-href]
 [![npm downloads][npm-downloads-src]][npm-downloads-href]
@@ -10,7 +19,7 @@ Vite plugin that enables a MCP server for your Vue app to provide information ab
 ## Installation 📦
 
 ```bash
-pnpm install vite-plugin-vue-mcp -D
+pnpm install @nonfx/vite-plugin-vue-mcp -D
 ```
 
 ## Usage 🔨
@@ -152,11 +161,11 @@ This project is inspired by [vite-plugin-mcp](https://github.com/antfu/nuxt-mcp/
 
 <!-- Badges -->
 
-[npm-version-src]: https://img.shields.io/npm/v/vite-plugin-vue-mcp?style=flat&colorA=080f12&colorB=1fa669
-[npm-version-href]: https://npmjs.com/package/vite-plugin-vue-mcp
-[npm-downloads-src]: https://img.shields.io/npm/dm/vite-plugin-vue-mcp?style=flat&colorA=080f12&colorB=1fa669
-[npm-downloads-href]: https://npmjs.com/package/vite-plugin-vue-mcp
-[bundle-src]: https://img.shields.io/bundlephobia/minzip/vite-plugin-vue-mcp?style=flat&colorA=080f12&colorB=1fa669&label=minzip
-[bundle-href]: https://bundlephobia.com/result?p=vite-plugin-vue-mcp
-[license-src]: https://img.shields.io/github/license/webfansplz/vite-plugin-vue-mcp.svg?style=flat&colorA=080f12&colorB=1fa669
-[license-href]: https://github.com/webfansplz/vite-plugin-vue-mcp/blob/main/LICENSE
+[npm-version-src]: https://img.shields.io/npm/v/@nonfx/vite-plugin-vue-mcp?style=flat&colorA=080f12&colorB=1fa669
+[npm-version-href]: https://npmjs.com/package/@nonfx/vite-plugin-vue-mcp
+[npm-downloads-src]: https://img.shields.io/npm/dm/@nonfx/vite-plugin-vue-mcp?style=flat&colorA=080f12&colorB=1fa669
+[npm-downloads-href]: https://npmjs.com/package/@nonfx/vite-plugin-vue-mcp
+[bundle-src]: https://img.shields.io/bundlephobia/minzip/@nonfx/vite-plugin-vue-mcp?style=flat&colorA=080f12&colorB=1fa669&label=minzip
+[bundle-href]: https://bundlephobia.com/result?p=@nonfx/vite-plugin-vue-mcp
+[license-src]: https://img.shields.io/github/license/NikhilVerma/vite-plugin-vue-mcp.svg?style=flat&colorA=080f12&colorB=1fa669
+[license-href]: https://github.com/NikhilVerma/vite-plugin-vue-mcp/blob/main/LICENSE

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vite-plugin-vue-mcp",
+  "name": "@nonfx/vite-plugin-vue-mcp",
   "type": "module",
   "version": "0.3.2",
   "packageManager": "pnpm@10.6.2",
@@ -7,12 +7,12 @@
   "author": "Arlo <webfansplz@gmail.com>",
   "license": "MIT",
   "funding": "https://github.com/sponsors/webfansplz",
-  "homepage": "https://github.com/webfansplz/vite-plugin-vue-mcp#readme",
+  "homepage": "https://github.com/NikhilVerma/vite-plugin-vue-mcp#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/webfansplz/vite-plugin-vue-mcp.git"
+    "url": "git+https://github.com/NikhilVerma/vite-plugin-vue-mcp.git"
   },
-  "bugs": "https://github.com/webfansplz/vite-plugin-vue-mcp/issues",
+  "bugs": "https://github.com/NikhilVerma/vite-plugin-vue-mcp/issues",
   "keywords": [
     "vite-plugin",
     "vue",

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -14,6 +14,7 @@ export async function setupRoutes(base: string, server: McpServer, vite: ViteDev
     debug('SSE Connected %s', transport.sessionId)
     res.on('close', () => {
       transports.delete(transport.sessionId)
+      server.close().catch(() => {})
     })
     await server.connect(transport)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
     : updateCursorMcpJson
 
   let config: ResolvedConfig
+  let isNuxt = false
   const vueMcpPath = getVueMcpPath()
   const vueMcpOptionsImportee = 'virtual:vue-mcp-options'
   const resolvedVueMcpOptions = `\0${vueMcpOptionsImportee}`
@@ -93,6 +94,8 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
     },
     configResolved(resolvedConfig) {
       config = resolvedConfig
+      // Nuxt does not run transformIndexHtml, detect it so we can inject via transform instead
+      isNuxt = resolvedConfig.plugins.some(p => p.name?.startsWith('nuxt:'))
     },
     transform(code, id, _options) {
       if (_options?.ssr)
@@ -106,6 +109,11 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
           (typeof appendTo === 'string' && filename.endsWith(appendTo))
           || (appendTo instanceof RegExp && appendTo.test(filename)))) {
         code = `import 'virtual:vue-mcp-path:overlay.js';\n${code}`
+      }
+
+      // Auto-inject for Nuxt: transformIndexHtml is not called in Nuxt, target its app entry instead
+      if (!options.appendTo && isNuxt && filename.includes('nuxt/dist/app/entry')) {
+        code = \`import 'virtual:vue-mcp-path:overlay.js';\n\${code}\`
       }
 
       return code

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,140 +1,145 @@
-import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
-import type { RpcFunctions, VueMcpContext, VueMcpOptions } from './types'
-import { existsSync } from 'node:fs'
-import fs from 'node:fs/promises'
-import path from 'node:path'
-import { fileURLToPath } from 'node:url'
-import c from 'ansis'
-import { join } from 'pathe'
-import { normalizePath, searchForWorkspaceRoot } from 'vite'
-import { createRPCServer } from 'vite-dev-rpc'
-import { setupRoutes } from './connect'
-import { createVueMcpContext } from './context'
-import { createServerRpc } from './rpc'
+import { existsSync } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import c from "ansis";
+import { join } from "pathe";
+import type { Plugin, ResolvedConfig, ViteDevServer } from "vite";
+import { normalizePath, searchForWorkspaceRoot } from "vite";
+import { createRPCServer } from "vite-dev-rpc";
+import { setupRoutes } from "./connect";
+import { createVueMcpContext } from "./context";
+import { createServerRpc } from "./rpc";
+import type { RpcFunctions, VueMcpContext, VueMcpOptions } from "./types";
 
 function getVueMcpPath(): string {
-  const pluginPath = normalizePath(path.dirname(fileURLToPath(import.meta.url)))
-  return pluginPath.replace(/\/dist$/, '/\/src')
+    const pluginPath = normalizePath(path.dirname(fileURLToPath(import.meta.url)));
+    return pluginPath.replace(/\/dist$/, "/\/src");
 }
-const vueMcpResourceSymbol = '?__vue-mcp-resource'
+const vueMcpResourceSymbol = "?__vue-mcp-resource";
 
 export function VueMcp(options: VueMcpOptions = {}): Plugin {
-  const {
-    mcpPath = '/__mcp',
-    updateCursorMcpJson = true,
-    printUrl = true,
-    mcpServer = (vite: ViteDevServer, ctx: VueMcpContext) => import('./server').then(m => m.createMcpServerDefault(options, vite, ctx)),
-  } = options
+    const {
+        mcpPath = "/__mcp",
+        updateCursorMcpJson = true,
+        printUrl = true,
+        mcpServer = (vite: ViteDevServer, ctx: VueMcpContext) =>
+            import("./server").then((m) => m.createMcpServerDefault(options, vite, ctx))
+    } = options;
 
-  const cursorMcpOptions = typeof updateCursorMcpJson == 'boolean'
-    ? { enabled: updateCursorMcpJson }
-    : updateCursorMcpJson
+    const cursorMcpOptions =
+        typeof updateCursorMcpJson == "boolean"
+            ? { enabled: updateCursorMcpJson }
+            : updateCursorMcpJson;
 
-  let config: ResolvedConfig
-  let isNuxt = false
-  const vueMcpPath = getVueMcpPath()
-  const vueMcpOptionsImportee = 'virtual:vue-mcp-options'
-  const resolvedVueMcpOptions = `\0${vueMcpOptionsImportee}`
+    let config: ResolvedConfig;
+    let isNuxt = false;
+    const vueMcpPath = getVueMcpPath();
+    const vueMcpOptionsImportee = "virtual:vue-mcp-options";
+    const resolvedVueMcpOptions = `\0${vueMcpOptionsImportee}`;
 
-  const ctx = createVueMcpContext()
+    const ctx = createVueMcpContext();
 
-  return {
-    name: 'vite-plugin-mcp',
-    enforce: 'pre',
-    apply: 'serve',
-    async configureServer(vite) {
-      const rpc = createServerRpc(ctx)
+    return {
+        name: "vite-plugin-mcp",
+        enforce: "pre",
+        apply: "serve",
+        async configureServer(vite) {
+            const rpc = createServerRpc(ctx);
 
-      const rpcServer = createRPCServer<RpcFunctions, any>(
-        'vite-plugin-vue-mcp',
-        vite.ws,
-        rpc,
-        {
-          timeout: -1,
+            const rpcServer = createRPCServer<RpcFunctions, any>(
+                "vite-plugin-vue-mcp",
+                vite.ws,
+                rpc,
+                {
+                    timeout: -1
+                }
+            );
+            ctx.rpcServer = rpcServer;
+            ctx.rpc = rpc;
+
+            let mcp = await mcpServer(vite, ctx);
+            mcp = (await options.mcpServerSetup?.(mcp, vite)) || mcp;
+            await setupRoutes(mcpPath, mcp, vite);
+
+            const port = vite.config.server.port || 5173;
+            const root = searchForWorkspaceRoot(vite.config.root);
+
+            const sseUrl = `http://${options.host || "localhost"}:${port}${mcpPath}/sse`;
+
+            if (cursorMcpOptions.enabled) {
+                if (existsSync(join(root, ".cursor"))) {
+                    const mcp = existsSync(join(root, ".cursor/mcp.json"))
+                        ? JSON.parse(
+                              (await fs.readFile(join(root, ".cursor/mcp.json"), "utf-8")) || "{}"
+                          )
+                        : {};
+                    mcp.mcpServers ||= {};
+                    mcp.mcpServers[cursorMcpOptions.serverName || "vue-mcp"] = { url: sseUrl };
+                    await fs.writeFile(
+                        join(root, ".cursor/mcp.json"),
+                        `${JSON.stringify(mcp, null, 2)}\n`
+                    );
+                }
+            }
+
+            if (printUrl) {
+                setTimeout(() => {
+                    // eslint-disable-next-line no-console
+                    console.log(`${c.yellow.bold`  ➜  MCP:     `}Server is running at ${sseUrl}`);
+                }, 300);
+            }
         },
-      )
-      ctx.rpcServer = rpcServer
-      ctx.rpc = rpc
+        async resolveId(importee: string) {
+            if (importee === vueMcpOptionsImportee) {
+                return resolvedVueMcpOptions;
+            } else if (importee.startsWith("virtual:vue-mcp-path:")) {
+                const resolved = importee.replace("virtual:vue-mcp-path:", `${vueMcpPath}/`);
+                return `${resolved}${vueMcpResourceSymbol}`;
+            }
+        },
+        configResolved(resolvedConfig) {
+            config = resolvedConfig;
+            // Nuxt does not run transformIndexHtml, detect it so we can inject via transform instead
+            isNuxt = resolvedConfig.plugins.some((p) => p.name?.startsWith("nuxt:"));
+        },
+        transform(code, id, _options) {
+            if (_options?.ssr) return;
 
-      let mcp = await mcpServer(vite, ctx)
-      mcp = await options.mcpServerSetup?.(mcp, vite) || mcp
-      await setupRoutes(mcpPath, mcp, vite)
+            const appendTo = options.appendTo;
+            const [filename] = id.split("?", 2);
 
-      const port = vite.config.server.port || 5173
-      const root = searchForWorkspaceRoot(vite.config.root)
+            if (
+                appendTo &&
+                ((typeof appendTo === "string" && filename.endsWith(appendTo)) ||
+                    (appendTo instanceof RegExp && appendTo.test(filename)))
+            ) {
+                code = `import 'virtual:vue-mcp-path:overlay.js';\n${code}`;
+            }
 
-      const sseUrl = `http://${options.host || 'localhost'}:${port}${mcpPath}/sse`
+            // Auto-inject for Nuxt: transformIndexHtml is not called in Nuxt, target its app entry instead
+            if (!options.appendTo && isNuxt && filename.includes("nuxt/dist/app/entry")) {
+                code = `import 'virtual:vue-mcp-path:overlay.js';\n${code}`;
+            }
 
-      if (cursorMcpOptions.enabled) {
-        if (existsSync(join(root, '.cursor'))) {
-          const mcp = existsSync(join(root, '.cursor/mcp.json'))
-            ? JSON.parse(await fs.readFile(join(root, '.cursor/mcp.json'), 'utf-8') || '{}')
-            : {}
-          mcp.mcpServers ||= {}
-          mcp.mcpServers[cursorMcpOptions.serverName || 'vue-mcp'] = { url: sseUrl }
-          await fs.writeFile(join(root, '.cursor/mcp.json'), `${JSON.stringify(mcp, null, 2)}\n`)
+            return code;
+        },
+        transformIndexHtml(html) {
+            if (options.appendTo) return;
+
+            return {
+                html,
+                tags: [
+                    {
+                        tag: "script",
+                        injectTo: "head-prepend",
+                        attrs: {
+                            type: "module",
+                            src: `${config.base || "/"}@id/virtual:vue-mcp-path:overlay.js`
+                        }
+                    }
+                ]
+            };
         }
-      }
-
-      if (printUrl) {
-        setTimeout(() => {
-          // eslint-disable-next-line no-console
-          console.log(`${c.yellow.bold`  ➜  MCP:     `}Server is running at ${sseUrl}`)
-        }, 300)
-      }
-    },
-    async resolveId(importee: string) {
-      if (importee === vueMcpOptionsImportee) {
-        return resolvedVueMcpOptions
-      }
-      else if (importee.startsWith('virtual:vue-mcp-path:')) {
-        const resolved = importee.replace('virtual:vue-mcp-path:', `${vueMcpPath}/`)
-        return `${resolved}${vueMcpResourceSymbol}`
-      }
-    },
-    configResolved(resolvedConfig) {
-      config = resolvedConfig
-      // Nuxt does not run transformIndexHtml, detect it so we can inject via transform instead
-      isNuxt = resolvedConfig.plugins.some(p => p.name?.startsWith('nuxt:'))
-    },
-    transform(code, id, _options) {
-      if (_options?.ssr)
-        return
-
-      const appendTo = options.appendTo
-      const [filename] = id.split('?', 2)
-
-      if (appendTo
-        && (
-          (typeof appendTo === 'string' && filename.endsWith(appendTo))
-          || (appendTo instanceof RegExp && appendTo.test(filename)))) {
-        code = `import 'virtual:vue-mcp-path:overlay.js';\n${code}`
-      }
-
-      // Auto-inject for Nuxt: transformIndexHtml is not called in Nuxt, target its app entry instead
-      if (!options.appendTo && isNuxt && filename.includes('nuxt/dist/app/entry')) {
-        code = \`import 'virtual:vue-mcp-path:overlay.js';\n\${code}\`
-      }
-
-      return code
-    },
-    transformIndexHtml(html) {
-      if (options.appendTo)
-        return
-
-      return {
-        html,
-        tags: [
-          {
-            tag: 'script',
-            injectTo: 'head-prepend',
-            attrs: {
-              type: 'module',
-              src: `${config.base || '/'}@id/virtual:vue-mcp-path:overlay.js`,
-            },
-          },
-        ],
-      }
-    },
-  }
+    };
 }


### PR DESCRIPTION
## Problems fixed

### 1. SSE reconnection throws "Already connected to a transport"

When an SSE client disconnects, the `McpServer` instance was left in a connected state. Any subsequent connection attempt (e.g. an MCP client restarting) threw:

```
Already connected to a transport. Call close() before connecting to a new transport,
or use a separate Protocol instance per connection.
```

The dev server had to be fully restarted to get MCP working again.

**Fix:** call `server.close()` in the SSE `close` event handler so the server resets before the next client connects.

```diff
 res.on('close', () => {
   transports.delete(transport.sessionId)
+  server.close().catch(() => {})
 })
```

### 2. Nuxt: overlay never loads, tool calls hang forever

Nuxt does not invoke `transformIndexHtml` during development, so `virtual:vue-mcp-path:overlay.js` was never injected into the page. The client-side RPC was never established, causing every MCP tool call to hang indefinitely waiting for a browser response.

**Fix:** detect Nuxt via its plugin name prefix (`nuxt:`) in `configResolved`, then inject the overlay import into Nuxt's app entry via the `transform` hook — the same mechanism the existing `appendTo` option already uses.

```diff
+    isNuxt = resolvedConfig.plugins.some(p => p.name?.startsWith('nuxt:'))
 ...
+    if (!options.appendTo && isNuxt && filename.includes('nuxt/dist/app/entry')) {
+      code = `import 'virtual:vue-mcp-path:overlay.js';\n${code}`
+    }
```

## Reproduction (both bugs)

1. Add the plugin to a Nuxt 3 project
2. Connect Claude Code (or any MCP client) via SSE
3. **Bug 1:** Restart the MCP client — observe the "Already connected" error, MCP broken until dev server restart
4. **Bug 2 (Nuxt only):** Even with a fresh connection, all tool calls hang — no component tree, no Pinia state, no router info returned