### PR TITLE
fix: SSE reconnection crash + Nuxt overlay injection

### DIFF
--- a/src/connect.ts
+++ b/src/connect.ts
@@ -14,6 +14,7 @@ export async function setupRoutes(base: string, server: McpServer, vite: ViteDev
     debug('SSE Connected %s', transport.sessionId)
     res.on('close', () => {
       transports.delete(transport.sessionId)
+      server.close().catch(() => {})
     })
     await server.connect(transport)
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
     : updateCursorMcpJson
 
   let config: ResolvedConfig
+  let isNuxt = false
   const vueMcpPath = getVueMcpPath()
   const vueMcpOptionsImportee = 'virtual:vue-mcp-options'
   const resolvedVueMcpOptions = `\0${vueMcpOptionsImportee}`
@@ -93,6 +94,8 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
     },
     configResolved(resolvedConfig) {
       config = resolvedConfig
+      // Nuxt does not run transformIndexHtml, detect it so we can inject via transform instead
+      isNuxt = resolvedConfig.plugins.some(p => p.name?.startsWith('nuxt:'))
     },
     transform(code, id, _options) {
       if (_options?.ssr)
@@ -106,6 +109,11 @@ export function VueMcp(options: VueMcpOptions = {}): Plugin {
           (typeof appendTo === 'string' && filename.endsWith(appendTo))
           || (appendTo instanceof RegExp && appendTo.test(filename)))) {
         code = `import 'virtual:vue-mcp-path:overlay.js';\n${code}`
+      }
+
+      // Auto-inject for Nuxt: transformIndexHtml is not called in Nuxt, target its app entry instead
+      if (!options.appendTo && isNuxt && filename.includes('nuxt/dist/app/entry')) {
+        code = \`import 'virtual:vue-mcp-path:overlay.js';\n\${code}\`
       }
 
       return code


### PR DESCRIPTION
## Problems fixed

### 1. SSE reconnection throws "Already connected to a transport"

When an SSE client disconnects, the `McpServer` instance was left in a connected state. Any subsequent connection attempt (e.g. an MCP client restarting) threw:

```
Already connected to a transport. Call close() before connecting to a new transport,
or use a separate Protocol instance per connection.
```

The dev server had to be fully restarted to recover.

**Fix:** call `server.close()` in the SSE `close` event handler so the server resets before the next client connects.

```diff
 res.on('close', () => {
   transports.delete(transport.sessionId)
+  server.close().catch(() => {})
 })
```

### 2. Nuxt: overlay never loads, tool calls hang forever

Nuxt does not invoke `transformIndexHtml` during development, so `virtual:vue-mcp-path:overlay.js` was never injected into the page. The client-side RPC was never established, causing every MCP tool call to hang indefinitely.

**Fix:** detect Nuxt via its plugin name prefix (`nuxt:`) in `configResolved`, then inject the overlay import into Nuxt's app entry via the `transform` hook — the same mechanism the existing `appendTo` option already uses.

```diff
+    isNuxt = resolvedConfig.plugins.some(p => p.name?.startsWith('nuxt:'))
 ...
+    if (!options.appendTo && isNuxt && filename.includes('nuxt/dist/app/entry')) {
+      code = `import 'virtual:vue-mcp-path:overlay.js';\n${code}`
+    }
```